### PR TITLE
libGL.so.1 Resolving Deficiencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
+RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixed the following error in the process of importing OpenCV on the Docker environment. For example, the same error occurs when running `convert2onnx.py` in the tools folder.
```
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```