### PR TITLE
Add the onnxsim support

### DIFF
--- a/tnn_runtime.md
+++ b/tnn_runtime.md
@@ -4,8 +4,9 @@ The doc introduces how to convert models into TNN.
 
 **step 1**, convert your model to ONNX, run:
 
-```
+```shell
 python3 tools/convert2onnx.py <config-file> --input-img <img-dir> --shape 512 512 --checkpoint <model-ckpt>
+# if you want to use onnxsim, you could invoke it just by adding `--onnxsim`
 ```
 
 **step 2**, clone the TNN:


### PR DESCRIPTION
Hi, onnxsim is a wonderfull onnx graph optimizer. I think it may be useful for the deploy of topformer!
It could remove some unuseful ops in onnx graph and sometimes accelerate the computing.  After the simplifying, the model could support more deploy ways, like ncnn, etc.
![image](https://user-images.githubusercontent.com/77330637/197402727-1dae29f5-e050-43a0-ac17-e7a60f582395.png)
